### PR TITLE
Maven variable pointing to project base directory fixed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
                         </goals>
                         <configuration>
                             <scriptpath>
-                                <element>${basedir}/src/main/script</element>
+                                <element>${project.basedir}/src/main/script</element>
                             </scriptpath>
                             <source>
                                 OUIUpdater.update(project)


### PR DESCRIPTION
The notation ${project.basedir} fix error while executing groovy script.